### PR TITLE
Pull request for your consideration

### DIFF
--- a/exact-target.gemspec
+++ b/exact-target.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{exact-target}
-  s.version = "0.1.7"
+  s.version = "0.1.8"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
   s.authors = ["David McCullars", "Paul Nock"]

--- a/exact-target.gemspec
+++ b/exact-target.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{exact-target}
-  s.version = "0.1.8"
+  s.version = "0.1.7"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
   s.authors = ["David McCullars", "Paul Nock"]

--- a/exact-target.gemspec
+++ b/exact-target.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{exact-target}
-  s.version = "0.1.6"
+  s.version = "0.1.7"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
   s.authors = ["David McCullars", "Paul Nock"]

--- a/lib/exact_target/response_handler.rb
+++ b/lib/exact_target/response_handler.rb
@@ -17,7 +17,7 @@ module ExactTarget
 
     %w(email job list subscriber triggered_send).each do |t|
       define_method "handle_#{t}_id_result", lambda { |resp|
-        handle_id_result resp, "#{t}_info", "#{t}_description", /success/i
+        handle_id_result resp, "#{t}_info", "#{t}_description", /success|sucess/i
       }
     end
 


### PR DESCRIPTION
Thanks for the GEM! We've been using it for our Exact Target integration. 

Feel free to take a look at my modifications:

I added some triggered send support, and also switched 'send_to_exact_target' to http POST instead of GET. In our case, we were starting to generate some long xml parameters and we didn't want to run into size limits for GET.  I'm not completely sure how generic the triggered send xml is, but it works well in our case.  I'm not sure if the different Exact Target Account types affect this.

Additionally, we were seeing some issues trying to register Facebook proxy email addresses with Exact Target, for example app+asdfadsfasdfasdf@proxymail.facebook.com.  It was easier to simply POST this data than trying to properly escape the + in the data.

regards,
Paul Nock
