### PR TITLE
Escape '+' sign 

### DIFF
--- a/lib/exact_target.rb
+++ b/lib/exact_target.rb
@@ -72,7 +72,7 @@ module ExactTarget
     def send_to_exact_target(request)
       verify_configure
 
-      data = "qf=xml&xml=#{URI.escape(URI.escape(request), "&")}"
+      data = "qf=xml&xml=#{URI.escape(URI.escape(request), "&+")}"
       uri = URI.parse(configuration.base_url)
 
       http = net_http_or_proxy.new(uri.host, uri.port)


### PR DESCRIPTION
 Added '+' to the URI escape of the request.  Exact Target doesn't handle the '+' sign correctly.  Valid email address like foo+bar@gmail.com get rejected unless the '+' is escaped.
